### PR TITLE
Fix source urls

### DIFF
--- a/haxe-deps-0.0.1-7.rockspec
+++ b/haxe-deps-0.0.1-7.rockspec
@@ -1,0 +1,25 @@
+package = "haxe-deps"
+version = "0.0.1-7"
+
+source = {
+   url = "https://github.com/jdonaldson/haxe-deps.git"
+}
+
+description = {
+   homepage = "https://github.com/jdonaldson/haxe-deps",
+   license  = "MIT"
+}
+
+dependencies = {
+   "lrexlib-pcre == 2.8.0-1",
+   "luv          == 1.36.0-0",
+   "luasocket    == 3.0rc1-2",
+   "luautf8      == 0.1.1-1",
+   "bit32        >= 5.0.0",
+   "hx-lua-simdjson >= 0.0.1-1"
+}
+
+build = {
+   type = "none",
+   modules = {}
+}

--- a/haxe-deps-0.0.1-7.rockspec
+++ b/haxe-deps-0.0.1-7.rockspec
@@ -2,7 +2,7 @@ package = "haxe-deps"
 version = "0.0.1-7"
 
 source = {
-   url = "https://github.com/jdonaldson/haxe-deps.git"
+   url = "git+https://github.com/jdonaldson/haxe-deps.git"
 }
 
 description = {

--- a/haxe-deps-scm-3.rockspec
+++ b/haxe-deps-scm-3.rockspec
@@ -2,7 +2,7 @@ package = "haxe-deps"
 version = "scm-3"
 
 source = {
-   url = "https://github.com/jdonaldson/haxe-deps.git"
+   url = "git+https://github.com/jdonaldson/haxe-deps.git"
 }
 
 description = {

--- a/haxe-deps-scm-3.rockspec
+++ b/haxe-deps-scm-3.rockspec
@@ -1,0 +1,25 @@
+package = "haxe-deps"
+version = "scm-3"
+
+source = {
+   url = "https://github.com/jdonaldson/haxe-deps.git"
+}
+
+description = {
+   homepage = "https://github.com/jdonaldson/haxe-deps",
+   license  = "MIT"
+}
+
+dependencies = {
+   "lrexlib-pcre",
+   "luv",
+   "luasocket",
+   "luautf8",
+   "bit32",
+   "hx-lua-simdjson"
+}
+
+build = {
+   type = "none",
+   modules = {}
+}


### PR DESCRIPTION
`git:` protocol causes error `the unauthenticated git protocol on port 9418 is no longer supported`